### PR TITLE
Closes #33: Generate entities txt file from drive files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,4 +150,5 @@ sql/.project
 
 data/entities_to_retrieve.txt
 data/entities_automatic.txt
+data/entities_to_retrieve_test.txt
 data/log.txt

--- a/src/automatically_download_hashtags_users_sheet.py
+++ b/src/automatically_download_hashtags_users_sheet.py
@@ -1,6 +1,5 @@
 """
-This process aims at automating the update of the file 'entities_to_retrive.txt',
- used for downloading tweets from Twitter.
+This process aims at automatically downloading new hashtags and users from our Google spreadsheets.
 """
 
 from __future__ import print_function

--- a/src/update_entities_to_retrieve_txt.py
+++ b/src/update_entities_to_retrieve_txt.py
@@ -1,0 +1,41 @@
+"""
+This process aims at automating the update of the file 'entities_to_retrive.txt',
+ used for downloading tweets from Twitter.
+"""
+
+from __future__ import print_function
+
+from pathlib import Path
+import os
+import sys
+
+source_path = str(Path(os.path.abspath(__file__)).parent)
+data_path = Path(source_path).parent / 'data'
+if source_path not in sys.path:
+    sys.path.insert(0, source_path)
+
+import fire
+import pandas as pd
+
+
+def update_entities_to_retrieve():
+    """
+    Read users and hashtags from files coming from Drive spreadsheet and merge them together in the
+        entities_to_retrieve.txt file
+    """
+
+    users = pd.read_csv(data_path / 'original_users.csv', usecols=['username']).rename(columns={'username': 'entity'})
+    hashtags = pd.read_csv(data_path / 'original_hashtags.csv', usecols=['hashtag']).rename(columns={'hashtag':
+                                                                                                         'entity'})
+
+    pd.concat([users, hashtags]).to_csv(data_path / 'entities_to_retrieve_test.txt', header=False, index=False)
+    # TODO: Change 'entities_to_retrieve_test' to 'entities_to_retrieve' once we want to put this in "production"
+
+
+if __name__ == '__main__':
+
+    # python src/update_entities_to_retrieve_txt.py update_entities_to_retrieve
+    fire.Fire()
+
+    # For debugging
+    # update_entities_to_retrieve()


### PR DESCRIPTION
A partir dels dos fitxers _original_users.csv_ i _original_hashtags.csv_, que vénen de la descàrrega automàtica del Drive, generem el fitxer _entities_to_retrieve.txt_.

De moment, el fitxer que es genera és un test. Quan ho vulguem posar a producció, s'haurà de canviar el nom!